### PR TITLE
fix rawLogs condition lookup

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,9 +12,7 @@ module.exports = {
     let log = receipt.logs[eventIndex];
     let rawLog = receipt.rawLogs[eventIndex];
 
-    if (log != undefined) {
-      txObject.logs  = [{"event":log.event}];
-    } else if (rawLog != undefined) {
+    if (rawLog != undefined) {
       let _decoded   = abiDecoder.decodeLogs([rawLog]);
       let decodedLog = _decoded[0];
       for (var i = 0; i < decodedLog.events.length; i++) {
@@ -24,7 +22,9 @@ module.exports = {
       }
       txObject.logs  = [{"event":decodedLog.name}];
       txObject.logs[0].args = tempArgs;
-    }
+    } else if (log != undefined) {
+      txObject.logs  = [{"event":log.event}];
+    };
 
     txObject.tx    = transaction.tx;
     return txObject;


### PR DESCRIPTION
Seems it doesn't work properly if you have emitted event in Foo contract after the event in Bar contract. In such case you have LogAlphabet event in receipt.rawLogs[0], but LogNumber event in receipt.logs[0]. And your condition will always return the LogNumber event, even if you try to get LogAlphabet event by index 0.